### PR TITLE
Add Hindsight - AI agent memory by Vectorize

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Contributions are welcome! Please submit a pull request or open an issue if you 
 | [Mem0](https://mem0.ai/) | Mem0 is a self-improving memory layer for LLM applications, enabling personalized AI experiences that save costs and delight users. | [Documentation](https://docs.mem0.ai/) \| [GitHub](https://github.com/mem0ai/mem0) |
 | [Memary](https://github.com/kingjulio8238/Memary) | Open Source Memory Layer For Autonomous Agents. | [GitHub](https://github.com/kingjulio8238/Memary) |
 | [Memobase](https://www.memobase.io/) | 1st User Profile-Based Memory for GenAI Apps. | [Documentation](https://docs.memobase.io/introduction) \| [GitHub](https://github.com/memodb-io/memobase) |
+| [Hindsight](https://hindsight.vectorize.io/) | State-of-the-art long-term memory for AI agents by Vectorize. Open source and fully self-hostable with integrations for LangChain, CrewAI, LlamaIndex, and more. | [Documentation](https://hindsight.vectorize.io/integrations) \| [GitHub](https://github.com/vectorize-io/hindsight) |
 
 ## LLMOps
 


### PR DESCRIPTION
## Summary
- Adds [Hindsight](https://hindsight.vectorize.io/) to the **LLM Memory** section
- Hindsight is a state-of-the-art, open-source long-term memory layer for AI agents by Vectorize
- MIT-licensed and fully self-hostable (`pip install hindsight-all`), with integrations for LangChain, LlamaIndex, CrewAI, Pydantic AI, Vercel AI SDK, and many more

## Why it fits
Hindsight is a direct fit for the LLM Memory section alongside Mem0, Memary, and Memobase — it provides persistent memory capabilities for LLM-powered agents and applications.