### PR TITLE
Add BGPT to Deep Research Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Contributions are welcome! Please submit a pull request or open an issue if you 
 |-------------|------------------|-----------|
 | [HuggingFace OpenDeepResearch](https://huggingface.co/blog/open-deep-research) | Open version of OpenAI's Deep Research agent. | [Blog](https://huggingface.co/blog/open-deep-research) \| [Example](https://github.com/huggingface/smolagents/blob/gaia-submission-r1/examples/open_deep_research/visual_vs_text_browser.ipynb) \| [GitHub](https://github.com/huggingface/smolagents/tree/gaia-submission-r1/examples/open_deep_research) |
 | [OpenDeepResearcher](https://github.com/mshumer/OpenDeepResearcher) | AI researcher that continuously searches for information based on a user query until the system is confident that it has gathered all the necessary details. | [GitHub](https://github.com/mshumer/OpenDeepResearcher) |
+| [BGPT](https://bgpt.pro) | MCP server for searching scientific papers built from raw experimental data extracted from full-text studies. Returns structured results with raw data, methods, results, quality scores, and 25+ metadata fields. | [Website](https://bgpt.pro) \| [MCP Setup](https://bgpt.pro/mcp) \| [GitHub](https://github.com/BioGPT-Pro/bgpt-mcp) |
 
 ## AI Frameworks (Build Your Own)
 


### PR DESCRIPTION
## Summary

- Adds [BGPT](https://bgpt.pro) to the **Deep Research Agents** section
- BGPT is an MCP server for searching scientific papers built from raw experimental data extracted from full-text studies
- Returns structured results with raw data, methods, results, quality scores, and 25+ metadata fields
- Includes 50 free searches per network, making it accessible for researchers and data scientists

## Why this fits

BGPT enables AI agents and data scientists to programmatically search and retrieve structured scientific paper data, making it a natural complement to the existing deep research tools in this list.


Made with [Cursor](https://cursor.com)