### PR TITLE
Add Dakera to LLM Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ Contributions are welcome! Please submit a pull request or open an issue if you 
 | [Mem0](https://mem0.ai/) | Mem0 is a self-improving memory layer for LLM applications, enabling personalized AI experiences that save costs and delight users. | [Documentation](https://docs.mem0.ai/) \| [GitHub](https://github.com/mem0ai/mem0) |
 | [Memary](https://github.com/kingjulio8238/Memary) | Open Source Memory Layer For Autonomous Agents. | [GitHub](https://github.com/kingjulio8238/Memary) |
 | [Memobase](https://www.memobase.io/) | 1st User Profile-Based Memory for GenAI Apps. | [Documentation](https://docs.memobase.io/introduction) \| [GitHub](https://github.com/memodb-io/memobase) |
+| [Dakera](https://github.com/Dakera-AI/dakera) | Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay, and multi-tenant namespacing. | [Documentation](https://github.com/Dakera-AI/dakera) \| [GitHub](https://github.com/Dakera-AI/dakera) |
 
 ## LLMOps
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Contributions are welcome! Please submit a pull request or open an issue if you 
 | [Mem0](https://mem0.ai/) | Mem0 is a self-improving memory layer for LLM applications, enabling personalized AI experiences that save costs and delight users. | [Documentation](https://docs.mem0.ai/) \| [GitHub](https://github.com/mem0ai/mem0) |
 | [Memary](https://github.com/kingjulio8238/Memary) | Open Source Memory Layer For Autonomous Agents. | [GitHub](https://github.com/kingjulio8238/Memary) |
 | [Memobase](https://www.memobase.io/) | 1st User Profile-Based Memory for GenAI Apps. | [Documentation](https://docs.memobase.io/introduction) \| [GitHub](https://github.com/memodb-io/memobase) |
-| [Dakera](https://github.com/Dakera-AI/dakera) | Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay, and multi-tenant namespacing. | [Documentation](https://github.com/Dakera-AI/dakera) \| [GitHub](https://github.com/Dakera-AI/dakera) |
+| [Dakera](https://github.com/dakera-ai/dakera-deploy) | Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay, and multi-tenant namespacing. | [Documentation](https://github.com/dakera-ai/dakera-deploy) \| [GitHub](https://github.com/dakera-ai/dakera-deploy) |
 
 ## LLMOps
 


### PR DESCRIPTION
## Adding Dakera to the LLM Memory section

[Dakera](https://github.com/Dakera-AI/dakera) is a production-ready persistent memory layer for AI agents — a natural fit alongside Mem0, Memary, and Memobase in the LLM Memory section.

**Key capabilities:**
- Hybrid BM25 + vector retrieval for accurate memory recall (keyword AND semantic)
- Temporal reasoning — handles time-relative queries natively
- Importance-weighted memory decay (relevant memories persist, noise fades automatically)
- Multi-tenant namespacing for isolated per-user/per-agent memory contexts
- Integrations with LangChain, LlamaIndex, CrewAI, and AutoGen

**Install:**
```bash
pip install dakera
```

Dakera's approach differs from pure vector stores by adding a full memory management lifecycle — from storage through retrieval, decay, and multi-tenant isolation.
