### PR TITLE
Add Dakera to LLM Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,8 @@ Contributions are welcome! Please submit a pull request or open an issue if you 
 | [Memary](https://github.com/kingjulio8238/Memary) | Open Source Memory Layer For Autonomous Agents. | [GitHub](https://github.com/kingjulio8238/Memary) |
 | [Memobase](https://www.memobase.io/) | 1st User Profile-Based Memory for GenAI Apps. | [Documentation](https://docs.memobase.io/introduction) \| [GitHub](https://github.com/memodb-io/memobase) |
 
+| [Dakera](https://github.com/dakera-ai/dakera-deploy) | Production-ready persistent memory layer for AI agents: hybrid BM25 + vector retrieval, temporal reasoning, importance-weighted decay, and multi-tenant namespacing. | [Documentation](https://github.com/dakera-ai/dakera-deploy) \| [GitHub](https://github.com/dakera-ai/dakera-deploy) |
+
 ## LLMOps
 
 | **Project** | **Description** | **Links** |


### PR DESCRIPTION
## Description

Adds [Dakera](https://github.com/dakera-ai/dakera-deploy) — a production-ready, self-hosted agent memory server.

**Key features:**
- Hybrid BM25 + HNSW vector retrieval for high-recall semantic search
- Decay-weighted recall (importance fades over time, like human memory)
- Multi-agent namespacing with per-namespace isolation
- MCP-native integration — works with Claude Code, Cursor, Windsurf, and any MCP client
- SDKs for Python, TypeScript, Go, and Rust

Open-source (Apache 2.0), self-hosted, production-ready.
