### PR TITLE
Add Agent Memory Techniques to LLM Memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Contributions are welcome! Please submit a pull request or open an issue if you 
 |-------------|------------------|-----------|
 | [Mem0](https://mem0.ai/) | Mem0 is a self-improving memory layer for LLM applications, enabling personalized AI experiences that save costs and delight users. | [Documentation](https://docs.mem0.ai/) \| [GitHub](https://github.com/mem0ai/mem0) |
 | [Memary](https://github.com/kingjulio8238/Memary) | Open Source Memory Layer For Autonomous Agents. | [GitHub](https://github.com/kingjulio8238/Memary) |
+| [Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques) | 30 runnable notebooks on agent/LLM memory: buffers, vector stores, knowledge graphs, episodic and semantic memory, Mem0, MemGPT/Letta, Zep, Graphiti, and LoCoMo benchmarks. | [GitHub](https://github.com/NirDiamant/Agent_Memory_Techniques) |
 | [Memobase](https://www.memobase.io/) | 1st User Profile-Based Memory for GenAI Apps. | [Documentation](https://docs.memobase.io/introduction) \| [GitHub](https://github.com/memodb-io/memobase) |
 
 ## LLMOps


### PR DESCRIPTION
Adds [Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques) to the **LLM Memory** section — 30 runnable notebooks covering agent/LLM memory end to end (buffers, vector stores, knowledge graphs, episodic/semantic memory, Mem0, MemGPT/Letta, Zep, Graphiti, LoCoMo benchmarks). Matched the 3-column table format.